### PR TITLE
Fix/8 yaml serialization conformity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+venv/
+.idea/

--- a/action.yaml
+++ b/action.yaml
@@ -88,7 +88,7 @@ runs:
         python-version: '3.10' 
 
     - name: Install python libraries 
-      run: pip install pyyaml requests
+      run: pip install requests ruamel-yaml==0.17.33
       shell: bash
 
     - name: Setup STK CLI

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+certifi==2024.2.2
+charset-normalizer==3.3.2
+idna==3.6
+requests==2.31.0
+urllib3==2.2.1
+ruamel-yaml==0.17.33

--- a/runtime.py
+++ b/runtime.py
@@ -154,14 +154,13 @@ if r1.status_code == 200:
                 headers=deploy_headers,
                 data=request_data
             )
-    if manifestoType == 'shared-infrastructure':
+    elif manifestoType == 'shared-infrastructure':
         self_hosted_deploy_infra_url = "https://runtime-manager.v1.stackspot.com/v1/run/self-hosted/deploy/infra"
         r2 = requests.post(
                 url=self_hosted_deploy_infra_url, 
                 headers=deploy_headers,
                 data=request_data
             )
-
     else:
         print("- MANIFESTO TYPE not recognized. Please, check the input.")
         exit(1)

--- a/runtime.py
+++ b/runtime.py
@@ -1,12 +1,29 @@
 import os
 import requests
-import yaml
 import json
 from pathlib import Path
+from ruamel.yaml import YAML
+from io import StringIO
 
-def save_output(name: str, value: str): 
+
+def yaml() -> YAML:
+    yml = YAML()
+    yml.indent(mapping=2, sequence=4, offset=2)
+    yml.allow_unicode = True
+    yml.default_flow_style = False
+    yml.preserve_quotes = True
+    return yml
+
+
+def safe_load(content: str) -> dict:
+    yml = yaml()
+    return yml.load(StringIO(content))
+
+
+def save_output(name: str, value: str):
     with open(os.environ['GITHUB_OUTPUT'], 'a') as output_file:
         print(f'{name}={value}', file=output_file)
+
 
 ACTION_PATH = os.getenv("ACTION_PATH")
 CLIENT_ID = os.getenv("CLIENT_ID")
@@ -27,19 +44,19 @@ if None in inputs_list:
 with open(Path(ACTION_PATH+'/manifest.yaml'), 'r') as file:
     manifesto_yaml = file.read()
 
-manifesto_dict = yaml.safe_load(manifesto_yaml)
+manifesto_dict = safe_load(manifesto_yaml)
 
 if VERBOSE is not None:
     print("- MANIFESTO:", manifesto_dict)
 
 manifestoType = manifesto_dict["manifesto"]["kind"]
-appOrInfraId= manifesto_dict["manifesto"]["spec"]["id"]
+appOrInfraId = manifesto_dict["manifesto"]["spec"]["id"]
 
 print(f"{manifestoType} project identified, with ID: {appOrInfraId}")
 
 iam_url = f"https://auth.stackspot.com/{CLIENT_REALM}/oidc/oauth/token"
 iam_headers = {'Content-Type': 'application/x-www-form-urlencoded'}
-iam_data = { "client_id":f"{CLIENT_ID}", "grant_type":"client_credentials", "client_secret":f"{CLIENT_KEY}" }
+iam_data = {"client_id": f"{CLIENT_ID}", "grant_type": "client_credentials", "client_secret": f"{CLIENT_KEY}"}
 
 print("Authenticating...")
 r1 = requests.post(
@@ -131,19 +148,23 @@ if r1.status_code == 200:
     print("Deploying Self-Hosted...")
 
     if manifestoType == 'application':
-        self_hosted_deploy_app_url="https://runtime-manager.v1.stackspot.com/v1/run/self-hosted/deploy/app"
+        self_hosted_deploy_app_url = "https://runtime-manager.v1.stackspot.com/v1/run/self-hosted/deploy/app"
         r2 = requests.post(
                 url=self_hosted_deploy_app_url, 
                 headers=deploy_headers,
                 data=request_data
             )
     if manifestoType == 'shared-infrastructure':
-        self_hosted_deploy_infra_url="https://runtime-manager.v1.stackspot.com/v1/run/self-hosted/deploy/infra"
+        self_hosted_deploy_infra_url = "https://runtime-manager.v1.stackspot.com/v1/run/self-hosted/deploy/infra"
         r2 = requests.post(
                 url=self_hosted_deploy_infra_url, 
                 headers=deploy_headers,
                 data=request_data
             )
+
+    else:
+        print("- MANIFESTO TYPE not recognized. Please, check the input.")
+        exit(1)
 
     if r2.status_code == 201:
         d2 = r2.json()


### PR DESCRIPTION
## Context 

This PR ensures conformity with CLI yaml serialization to avoid inconsistencies in manifesto serialization. 

## Changes

- Changed serialization library
- Code Structure to conform to PEP 8

## Evidences
I have uploaded these changes to STG branch and tested it in this [pipe](https://github.com/stack-spot/runtimes-cancel-action-validation/actions/runs/8193393403/job/22407053514).
<img width="1730" alt="Captura de Tela 2024-03-07 às 16 07 10" src="https://github.com/stack-spot/runtime-manager-action/assets/149098642/88920dcf-7905-4496-89f1-6f50cb30f02f">
