### PR TITLE
Remove Node 16 warning

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -87,7 +87,7 @@ runs:
       uses: actions/checkout@v4
 
     - name: Setup Python
-      uses: actions/setup-python@v4.7.1
+      uses: actions/setup-python@v5.1.0
       with:
         python-version: '3.10' 
 


### PR DESCRIPTION
Github Actions now send warnings when calling actions using Node 16. To prevent those warnings, we should update the internal actions used in our composite action to the latest versions. In this case, the `actions/setup-python`, to v5.1.0